### PR TITLE
Connection dialog fixes, join error fixes

### DIFF
--- a/src/com/mercuryirc/client/callback/CallbackImpl.java
+++ b/src/com/mercuryirc/client/callback/CallbackImpl.java
@@ -320,4 +320,19 @@ public class CallbackImpl implements Callback {
 		});
 	}
 
+    @Override
+    public void onJoinError(final Connection connection, final Channel channel, final String reason) {
+        Platform.runLater(new Runnable() {
+            @Override
+            public void run() {
+                Tab tab = appPane.getTabPane().get(connection, channel);
+                appPane.getTabPane().close(tab);
+                Toolkit.getDefaultToolkit().beep();
+
+                Message reasonMessage = new Message(null, null, channel.getName() + ": " + reason);
+                appPane.getTabPane().addUntargetedMessage(connection, reasonMessage, MessageRow.Type.ERROR);
+            }
+        });
+    }
+
 }

--- a/src/com/mercuryirc/client/ui/ConnectPane.java
+++ b/src/com/mercuryirc/client/ui/ConnectPane.java
@@ -19,6 +19,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 public class ConnectPane extends VBox {
+    public static final int DEFAULT_PORT = 6667;
 
 	private final ConnectStage stage;
 
@@ -45,7 +46,7 @@ public class ConnectPane extends VBox {
 				createHeader("network", true),
 				createField("Name", "Freenode", netName),
 				createField("Host", "irc.freenode.net", netHost),
-				createField("Port", "6667", netPort),
+				createField("Port", String.valueOf(DEFAULT_PORT), netPort),
 				createField("Password", "", netPass),
 				createField("SSL", "", netSsl),
 
@@ -61,7 +62,9 @@ public class ConnectPane extends VBox {
 		connectButton.setOnAction(new EventHandler<ActionEvent>() {
 			@Override
 			public void handle(ActionEvent actionEvent) {
-				Server server = new Server(netName.getText(), netHost.getText(), Integer.parseInt(netPort.getText()), netPass.getText().equals("") ? null : netPass.getText(), netSsl.isSelected());
+				Server server = new Server(netName.getText(), netHost.getText(), netPort.getText().equals("")
+                        ? DEFAULT_PORT : Integer.parseInt(netPort.getText()), netPass.getText().equals("") ?
+                        null : netPass.getText(), netSsl.isSelected());
 				User user = new User(server, userNick.getText(), userUser.getText(), userReal.getText());
 				if (!userPass.getText().equals("")) {
 					user.setNickservPassword(userPass.getText());


### PR DESCRIPTION
The values in empty fields in the connect dialog make the user imply that the values there will be used as defaults, which wasn't the case for the Port field. For that reason I've added a default port in case the user doesn't fill it in.

Join errors weren't handled correctly, resulting in an open tab with … …
…no channel attached that may have caused some lockups/crashed. A new numeric command was added in mercury-lib for dealing with the situation of join errors caused by channels with keys or invite-only enabled.

This change potentially breaks compatibility with older versions of mercury-lib
